### PR TITLE
Move to latest Lombok, address hidden failIfVulns behavior

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,10 @@
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -138,7 +142,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>1.18.6</version>
             <scope>provided</scope>
 	</dependency>
         <!-- Test scope -->

--- a/src/main/java/com/synopsys/protecode/sc/jenkins/ProtecodeScPlugin.java
+++ b/src/main/java/com/synopsys/protecode/sc/jenkins/ProtecodeScPlugin.java
@@ -200,7 +200,9 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
     // TODO: Check credentials exists!
     if (workspace == null) {
       buildListener.error("No executor workspace, exiting. Has the build been able to create a workspace?");
-      run.setResult(Result.FAILURE);
+      if (failIfVulns) {
+        run.setResult(Result.FAILURE);
+      }
       return false;
     }
 
@@ -223,7 +225,9 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
     ProtecodeScService serv = service(run);
     if (serv == null) {
       buildListener.error("Cannot connect to " + Configuration.TOOL_NAME); // TODO use consoler also
-      run.setResult(Result.FAILURE);
+      if (failIfVulns) {
+        run.setResult(Result.FAILURE);
+      }
       return false;
     }
 
@@ -263,13 +267,17 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
       if (verdict.getFilesFound() == 0) {
         LOGGER.info("No files found, ending " + Configuration.TOOL_NAME + " phase.");
         console.log("No files found, ending " + Configuration.TOOL_NAME + " phase.");
-        run.setResult(Result.SUCCESS);
+        if (failIfVulns) {
+          run.setResult(Result.SUCCESS);
+        }
         return true;
       }
       if (endAfterSendingFiles) {
         LOGGER.info("Files sent, ending " + Configuration.TOOL_NAME + " phase due to configuration.");
         console.log("Files sent, ending phase.");
-        run.setResult(Result.SUCCESS);
+        if (failIfVulns) {
+          run.setResult(Result.SUCCESS);
+        }
         return true;
       }
       results = resultOp.get();
@@ -281,7 +289,9 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
       } // otherwise carry on, might get something
     } catch (InterruptedException ie) {
       console.log("Interrupted, stopping build");
-      run.setResult(Result.ABORTED);
+      if (failIfVulns) {
+        run.setResult(Result.ABORTED);
+      }
       return false;
     }
 
@@ -305,7 +315,9 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
       if (!verdict.verdict()) {
         console.printReportString(results);
         buildListener.fatalError(verdict.verdictStr());
-        run.setResult(Result.FAILURE);
+        if (failIfVulns) {
+          run.setResult(Result.FAILURE);
+        }
       } else {
         console.log("NO vulnerabilities found.");
       }
@@ -317,7 +329,6 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
         console.log("NO vulnerabilities found.");
       }
       buildStatus = true;
-      run.setResult(Result.SUCCESS);
     }
 
     console.log(Configuration.TOOL_NAME + " plugin end");

--- a/src/main/java/com/synopsys/protecode/sc/jenkins/ProtecodeScPlugin.java
+++ b/src/main/java/com/synopsys/protecode/sc/jenkins/ProtecodeScPlugin.java
@@ -203,6 +203,7 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
       if (failIfVulns) {
         run.setResult(Result.FAILURE);
       }
+
       return false;
     }
 
@@ -228,6 +229,7 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
       if (failIfVulns) {
         run.setResult(Result.FAILURE);
       }
+
       return false;
     }
 
@@ -267,17 +269,11 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
       if (verdict.getFilesFound() == 0) {
         LOGGER.info("No files found, ending " + Configuration.TOOL_NAME + " phase.");
         console.log("No files found, ending " + Configuration.TOOL_NAME + " phase.");
-        if (failIfVulns) {
-          run.setResult(Result.SUCCESS);
-        }
         return true;
       }
       if (endAfterSendingFiles) {
         LOGGER.info("Files sent, ending " + Configuration.TOOL_NAME + " phase due to configuration.");
         console.log("Files sent, ending phase.");
-        if (failIfVulns) {
-          run.setResult(Result.SUCCESS);
-        }
         return true;
       }
       results = resultOp.get();
@@ -288,10 +284,8 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
         return false;
       } // otherwise carry on, might get something
     } catch (InterruptedException ie) {
+      buildListener.error("Interrupted, stopping build");
       console.log("Interrupted, stopping build");
-      if (failIfVulns) {
-        run.setResult(Result.ABORTED);
-      }
       return false;
     }
 
@@ -315,9 +309,6 @@ public class ProtecodeScPlugin extends Builder implements SimpleBuildStep {
       if (!verdict.verdict()) {
         console.printReportString(results);
         buildListener.fatalError(verdict.verdictStr());
-        if (failIfVulns) {
-          run.setResult(Result.FAILURE);
-        }
       } else {
         console.log("NO vulnerabilities found.");
       }


### PR DESCRIPTION
My build was failing with error
```
Caused by: java.lang.ClassNotFoundException: com.sun.tools.javac.code.TypeTags
```
This was fixed in Lombok 1.16.22.

I am not sure if the Maven Central repository is actually needed; without this my system could not find the Lombok artifact, but that could be a local config issue -- obviously this repo is building elsewhere.