### PR TITLE
Move to latest Lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,10 @@
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -138,7 +142,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>1.18.6</version>
             <scope>provided</scope>
 	</dependency>
         <!-- Test scope -->


### PR DESCRIPTION
My build was failing with error
```
Caused by: java.lang.ClassNotFoundException: com.sun.tools.javac.code.TypeTags
```
This was fixed in Lombok 1.16.22.

I am not sure if the Maven Central repository is actually needed; without this my system could not find the Lombok artifact, but that could be a local config issue -- obviously this repo is building elsewhere.